### PR TITLE
Add PLCT-GNU team works in Nov

### DIFF
--- a/2021/2021-12-01.md
+++ b/2021/2021-12-01.md
@@ -98,6 +98,53 @@ https://github.com/openjdk-riscv/jdk11u/pull/265
 
 ## GNU Toolchain for RISC-V 相关工作
 
+- B扩展的任务已经告一段落，剩余的zbe,zbf,zbm,zbp,zbr,zbt预计会在明年spec正式public review以后进行更新并提交patch.
+
+- Scalar crypto扩展更新至1.0.0-rc6版本，向Upstream提交了GCC和Binutils的patch,目前Binutils的patch已经merge，GCC的patch仍在review中.
+
+GCC review意见: https://gcc.gnu.org/pipermail/gcc-patches/2021-November/585358.html
+
+Binutils commits: https://sourceware.org/git/?p=binutils-gdb.git&a=search&h=HEAD&st=commit&s=scalar+crypto
+
+c-api builtins/intrinsics实现参考： https://github.com/riscv-non-isa/riscv-c-api-doc/pull/23
+
+- P扩展更新至0.9.10版本，toolchain同步了版本更新，并对P扩展的指令添加了大量的测试用例.（等待release后会进行rebase...）
+
+测试用例： https://github.com/linsinan1995/riscv-gcc/commit/da54bacbc6dbef0d3e024b9a28436c0862befde7
+
+- Zfinx扩展向upstream提交了toolchain实现patch，目前Binutils部分已经merge，GCC部分还在review，由于目前Zfh的实现还未merge进入upstream，后续会等待Zfh合并后补充对应的Zhinx与Zhinxmin子扩展.
+
+GCC patch: https://gcc.gnu.org/pipermail/gcc-patches/2021-November/583437.html
+
+Binutils commits: https://sourceware.org/git/?p=binutils-gdb.git&a=search&h=HEAD&st=commit&s=z%5Bfdq%5Dinx
+
+- Zce扩展按照Tariq的要求添加了单个指令的option选项，用来验证单个指令在benchmark上的优化效果，rebase了Zcee的实现并提交到openhw下的core-v分支，目前正在等待review，zceb修复了decbnez，添加了指令的测试用例，zcea初步实现了c.pop指令.
+
+ZCE进展分享： https://docs.google.com/presentation/d/1zZtC8Ff9YIXGqBlC5qb2IuitTWOCln5iTgyCJPo8w40/edit#slide=id.g10436ebf8eb_0_92
+
+corev-gcc: https://github.com/openhwgroup/corev-gcc/pull/6
+
+corev-binutils: https://github.com/openhwgroup/corev-binutils-gdb/pull/40
+
+zceb: https://github.com/linsinan1995/riscv-gcc/tree/riscv-gcc-experiment-zceb
+
+zcea: https://github.com/linsinan1995/riscv-gcc/tree/riscv-gcc-experiment-zcea
+
+- Zmmul扩展是对乘法指令集M的一个分割，我们在toolchain上实现了zmmul扩展的支持，并向upstream提交了patch，预计等待Zmmul扩展完成public review后会进行合并.
+
+zmmul-gcc-patch: https://gcc.gnu.org/pipermail/gcc-patches/2021-October/582664.html
+
+zmmul-binutils-patch: https://sourceware.org/pipermail/binutils/2021-October/118308.html
+
+欢迎新员工史玉龙加入PLCT-GNU小队，目前正在学习积攒实力中，今天下午会进行第一次学习交流分享，期待他的表现...张益同学对SIMD比较感兴趣，目前已转入LLVM下的SIMD开发工作中
+
+[张益 - RISC-V Vector 扩展 1.0 vs 0.7](https://www.bilibili.com/video/BV1Jr4y1k7xo?spm_id_from=333.999.0.0)
+
+RISC-V-GNU-Toolchain双周会ppt：
+
+11-18: https://docs.google.com/presentation/d/11Tvp7YQ5rjwL-YpfdUqKmiE-0mNvMMuyn4SQfpjB4GI/edit#slide=id.gcf929d3017_1_2
+
+11-04: https://docs.google.com/presentation/d/1ZQzCSfUxlIgR_Bfd_RJh3rOdxfbKdg1_4F-UUkBDucE/edit#slide=id.p
 
 ## AOSP for RISC-V
 


### PR DESCRIPTION
Add PLCT-GNU team works in Nov, Which include RISC-V sub-extension toolchain implement status.