### PR TITLE
OpenJDK for RISC-V 2022年1月开源进展

### DIFF
--- a/2022/2022-02-01.md
+++ b/2022/2022-02-01.md
@@ -24,10 +24,32 @@
 ## OpenJDK for RISC-V
 
 ### 项目进展
+- 成功实现了解释器的移植！
 
+- 开展测试用例的调试工作，测试用例的仓库：https://github.com/openjdk-riscv/testcase-jdk11u-rv32g
+  目前能够覆盖long型数据的常见加减乘除、移位、异或、取反、强转、打印等运算指令的测试。
+  
+- RV32 core模式下的SPECjvm2008测试 https://github.com/openjdk-riscv/jdk11u/issues/331
+  目前能够跑通除了derby以外其他所有的case，覆盖率达到：33/34（97%）。
+
+- RV32 core模式下DaCapo benchmarks的测试 https://github.com/openjdk-riscv/jdk11u/issues/332
+  目前能够跑通avrora、h2、sunflow、jython等4个case，覆盖率达到：4/14（28.6%）。
+
+- RV32 core模式下的jtreg测试 https://github.com/openjdk-riscv/jdk11u/issues/333
+  目前正在测试验证中，部分测试集需要多次测试验证。
+  
+- Fix the sub logic of Long type（曹贵） https://github.com/openjdk-riscv/jdk11u/pull/299
+
+- Fix lmul, lcmp, lneg opcode （曹贵、章翔）https://github.com/openjdk-riscv/jdk11u/pull/309
+
+- Fix convert of long/double/float（张定立）https://github.com/openjdk-riscv/jdk11u/pull/325
+
+- Expand BUFFER_SIZE in jniFastGetField_riscv32.cpp（曹贵）https://github.com/openjdk-riscv/jdk11u/pull/328
+
+- Fix dconst in templateTable_riscv32.cpp（张定立）https://github.com/openjdk-riscv/jdk11u/pull/330
 
 ### 问题与文档：
-
+- OpenJDK for RISC-V模板表中opcode的参数弹出问题（史宁宁）https://zhuanlan.zhihu.com/p/457201723
 
 ## Clang/LLVM for RISC-V 相关工作
 


### PR DESCRIPTION
OpenJDK for RISC-V 2022年1月开源进展