### PR TITLE
2022/2022-09-01: fix link to OpenSBI AIA M-mode CSR naming patch

### DIFF
--- a/2022/2022-09-01.md
+++ b/2022/2022-09-01.md
@@ -509,7 +509,7 @@ New features:
 - 为C9xx添加PMU扩展。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003259.html)
 - Cadence UART驱动更新，主要添加初始化时除零的检测。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003252.html)
 - kconfig更新并合并。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003230.html)
-- 使用官方AIA M-Mode扩展名Smaia。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003280.html)
+- 使用官方AIA M-Mode扩展名Smaia。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003268.html)
 - 移除CSR(sideleg/sedeleg)，这两个CSR已经从标准中移除了。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003280.html)
 - opensbi pmu改进，优化内存使用（删除了fw\_event中的event id），添加结构sbi\_pmu\_device用于非标准pmu的接口，把firmware counter修改为固定的64比特。[link](https://lists.infradead.org/pipermail/opensbi/2022-August/003281.html)
 - 修正Unmatched关于pmu的文档。[link1](https://lists.infradead.org/pipermail/opensbi/2022-August/003292.html), [link2](https://lists.infradead.org/pipermail/opensbi/2022-August/003291.html)


### PR DESCRIPTION
The OpenSBI section in the September report referenced a bad link for the patch `lib: sbi: Use the official extension name for AIA M-mode CSRs`, which referenced the patch `include: Remove sideleg and sedeleg` instead.

This pull request fixes said link.