### PR TITLE
2022-11-02: Fix various Markdown formatting issues

### DIFF
--- a/2022/2022-11-01.md
+++ b/2022/2022-11-01.md
@@ -131,10 +131,10 @@
 ## GNU Toolchain for RISC-V 相关工作
 
 - rebase了zfinx扩展，添加了zhinx/zhinxmin支持，已合并到upstream：
-  https://gcc.gnu.org/git/?p=gcc.git&a=search&h=HEAD&st=commit&s=inx
+  - https://gcc.gnu.org/git/?p=gcc.git&a=search&h=HEAD&st=commit&s=inx
 
 - -m[no]-csr-check的patch修改后合并到upstream：
-  https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=32f86f2b54dc97cb6a40edef421b6a30c3bd1c04
+  - https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=32f86f2b54dc97cb6a40edef421b6a30c3bd1c04
 
 - 修复了回归测试中发现的一些问题，提交了patch，正在review中：
   - https://gcc.gnu.org/pipermail/gcc-patches/2022-October/603469.html
@@ -146,14 +146,13 @@
   - psabi讨论：https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/349
 
 - 在gcc中初步支持了profile，部分缺陷仍在解决中：
-  gcc仓库：https://github.com/pz9115/riscv-gcc/tree/riscv-gcc-profile
-  spec定义：https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20u64-mandatory-base
-  issue记录：https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/348
+  - gcc仓库：https://github.com/pz9115/riscv-gcc/tree/riscv-gcc-profile
+  - spec定义：https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20u64-mandatory-base
+  - issue记录：https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/348
 
 - RISC-V GNU Toolchain双周会slides:
   - 10.06: https://docs.google.com/presentation/d/1mtetMlzfYtf9JQ4pwn9BjDlnzE-IadqxQ9C6ypReg3s/edit?usp=sharing
-  - 10.20: https://docs.google.com/presentation/d/1Qc8oR1hXpxpvi0cxauuRWaQuqJLWN6AnJCQs7Z41qU8/edit?usp=sharing
-           https://docs.google.com/presentation/d/1djgRDht0DuAq21KH9njKSczED0EYNiMYSBx5D7EDREk/edit?usp=sharing
+  - 10.20: https://docs.google.com/presentation/d/1Qc8oR1hXpxpvi0cxauuRWaQuqJLWN6AnJCQs7Z41qU8/edit?usp=sharing, https://docs.google.com/presentation/d/1djgRDht0DuAq21KH9njKSczED0EYNiMYSBx5D7EDREk/edit?usp=sharing
 
 
 ## AOSP for RISC-V

--- a/2022/2022-11-01.md
+++ b/2022/2022-11-01.md
@@ -386,29 +386,29 @@ PLCT实验室的史宁宁依然每周在更新方舟编译器社区周报（Open
 
 Buddy Compiler OSPP 2022 圆满完成：
 
-- [OSPP] Add MatMul and Conv2d optimization pass. - https://github.com/buddy-compiler/buddy-mlir/pull/78 (王彦伟)
+- \[OSPP\] Add MatMul and Conv2d optimization pass. - https://github.com/buddy-compiler/buddy-mlir/pull/78 (王彦伟)
 
-- [OSPP] MatMul and Conv2d optimization benchmark. - https://github.com/buddy-compiler/buddy-benchmark/pull/47 (王彦伟)
+- \[OSPP\] MatMul and Conv2d optimization benchmark. - https://github.com/buddy-compiler/buddy-benchmark/pull/47 (王彦伟)
 
-- [OSPP] Frontend Generator. -  https://github.com/buddy-compiler/buddy-mlir/pull/75 (杨森)
+- \[OSPP\] Frontend Generator. -  https://github.com/buddy-compiler/buddy-mlir/pull/75 (杨森)
 
-- [OSPP] Add function support to ToyDSL. - https://github.com/buddy-compiler/buddy-mlir/pull/61 (杨森)
+- \[OSPP\] Add function support to ToyDSL. - https://github.com/buddy-compiler/buddy-mlir/pull/61 (杨森)
 
-- [OSPP] Add struct support to ToyDSL. - https://github.com/buddy-compiler/buddy-mlir/pull/65 (杨森)
+- \[OSPP\] Add struct support to ToyDSL. - https://github.com/buddy-compiler/buddy-mlir/pull/65 (杨森)
 
-- [OSPP] Added IIR Lowering pass(DAP dialect), with C++ wrapper along with end to end example. - https://github.com/buddy-compiler/buddy-mlir/pull/71 (Aman Chhaparia)
+- \[OSPP\] Added IIR Lowering pass(DAP dialect), with C++ wrapper along with end to end example. - https://github.com/buddy-compiler/buddy-mlir/pull/71 (Aman Chhaparia)
 
-- [OSPP] Add Biquad Lowering pass(DAP Dialect), with c++ wrapper along with end to end example. - https://github.com/buddy-compiler/buddy-mlir/pull/69 (Aman Chhaparia)
+- \[OSPP\] Add Biquad Lowering pass(DAP Dialect), with c++ wrapper along with end to end example. - https://github.com/buddy-compiler/buddy-mlir/pull/69 (Aman Chhaparia)
 
-- [OSPP] Add Biquad IIR Benchmark. - https://github.com/buddy-compiler/buddy-benchmark/pull/41 (Aman Chhaparia)
+- \[OSPP\] Add Biquad IIR Benchmark. - https://github.com/buddy-compiler/buddy-benchmark/pull/41 (Aman Chhaparia)
 
-- [OSPP] Added IIR (DAP dialect) Benchmark - https://github.com/buddy-compiler/buddy-benchmark/pull/44 (Aman Chhaparia)
+- \[OSPP\] Added IIR (DAP dialect) Benchmark - https://github.com/buddy-compiler/buddy-benchmark/pull/44 (Aman Chhaparia)
 
-- [OSPP] Morphological Transformations. - https://github.com/buddy-compiler/buddy-mlir/pull/82 (Rishabh Bali)
+- \[OSPP\] Morphological Transformations. - https://github.com/buddy-compiler/buddy-mlir/pull/82 (Rishabh Bali)
 
-- [OSPP] Benchmarks for Morphological operations. - https://github.com/buddy-compiler/buddy-benchmark/pull/45 (Rishabh Bali)
+- \[OSPP\] Benchmarks for Morphological operations. - https://github.com/buddy-compiler/buddy-benchmark/pull/45 (Rishabh Bali)
 
-- [OSPP] Add a new test flamework for libcxx-simd. - https://github.com/plctlab/llvm-project/pull/46 (史皓航)
+- \[OSPP\] Add a new test flamework for libcxx-simd. - https://github.com/plctlab/llvm-project/pull/46 (史皓航)
 
 ### Buddy Compiler
 

--- a/2022/2022-11-01.md
+++ b/2022/2022-11-01.md
@@ -94,13 +94,13 @@
 
 ## OpenJDK8 backporting （章翔）
 -代码提交
-- [Fix_uint_at_by_initializing_last_insn](https://github.com/zhangxiang-plct/jdk8u/pull/105)
+  - [Fix_uint_at_by_initializing_last_insn](https://github.com/zhangxiang-plct/jdk8u/pull/105)
   - [Fix barrierSet]:
     (https://github.com/zhangxiang-plct/jdk8u/pull/107)
     (https://github.com/zhangxiang-plct/jdk8u/pull/108)
     (https://github.com/zhangxiang-plct/jdk8u/pull/109)
     (https://github.com/zhangxiang-plct/jdk8u/pull/110)
-- [Fix stack_shadow_zone_size](https://github.com/zhangxiang-plct/jdk8u/pull/111)
+  - [Fix stack_shadow_zone_size](https://github.com/zhangxiang-plct/jdk8u/pull/111)
 
 ## Clang/LLVM for RISC-V 相关工作
 - 已经提交到主线的patch:
@@ -118,7 +118,8 @@
  https://reviews.llvm.org/D137060
 
 ## gollvm 相关工作
-  - 已经更新了patch。
+
+- 已经更新了patch。
 
 ## mold 相关工作
 
@@ -309,7 +310,7 @@ https://github.com/plctlab/gecko-dev-riscv
 - 修复了simd/simd\_mask类的隐式类型转换构造函数
 - 修复了vector aligned tag的alignment实现
 - 修复了scalar ABI下的广播构造函数与掩码赋值函数
-- 修复了带reszie\_simd的split\_by和concat函数
+- 修复了带resize\_simd的split\_by和concat函数
 
 ### 测试框架实现进展
 
@@ -343,12 +344,9 @@ Interpreter mode REPL running with temporary workarounds. Multiple comparison op
 ## Spike
 
 - 添加rv32u/s/vu/vs(可变*XLEN)的支持
-
-- - https://github.com/plctlab/plct-spike/tree/plct-rv32u-dev
-
+  - https://github.com/plctlab/plct-spike/tree/plct-rv32u-dev
 - 修复mmu以及编译warning的问题
-
-- - https://github.com/riscv-software-src/riscv-isa-sim/pull/1123
+  - https://github.com/riscv-software-src/riscv-isa-sim/pull/1123
 
 ## QEMU
 
@@ -463,22 +461,16 @@ New features:
 
 ## RVLab相关工作
 1.linux kernel CI相关
-- [WIP]按照 https://github.com/kernelci/lava-docker 用docker-compose起了一个用于测试qemu kernel的LAVA，学习LAVA的使用，包括：
-
-  创建了测试openEuler x86 qemu image的job，可以测试完成
-
-  创建了测试openEuler riscv64 qemu image的job，由于登录提示会重复出现2次，导致job无法执行完成
-
-  创建了测试Fedora riscv64 qemu image的job, 可以测试完成
-
-  修改lava-docker源代码，给lava-slave容器添加映射目录，给lava-master和lava-slave容器设置开机自动启动，以及解决LAVA web界面只能在部署主机使用 http://localhost:port 访问的问题。
-
+  - \[WIP\]按照 https://github.com/kernelci/lava-docker 用docker-compose起了一个用于测试qemu kernel的LAVA，学习LAVA的使用，包括：
+    - 创建了测试openEuler x86 qemu image的job，可以测试完成
+    - 创建了测试openEuler riscv64 qemu image的job，由于登录提示会重复出现2次，导致job无法执行完成
+    - 创建了测试Fedora riscv64 qemu image的job, 可以测试完成
+    - 修改lava-docker源代码，给lava-slave容器添加映射目录，给lava-master和lava-slave容器设置开机自动启动，以及解决LAVA web界面只能在部署主机使用 http://localhost:port 访问的问题。
 - 学习LTP测试套件相关内容，在本地的riscv64 ubuntu docker容器中编译和运行，并将执行步骤整理成文档 https://zhuanlan.zhihu.com/p/579009831
 
 2.rvlab基础设施
-- 由于一台unmatched debian系统启动失败，重新给它安装了系统
-
-- 配合于波老师解决debian升级后，无法ssh远程连接到rvlab unmatched的问题(这是debian中新版bash的一个bug)
+  - 由于一台unmatched debian系统启动失败，重新给它安装了系统
+  - 配合于波老师解决debian升级后，无法ssh远程连接到rvlab unmatched的问题(这是debian中新版bash的一个bug)
 
 ## 参考链接
 


### PR DESCRIPTION
This pull request fixes various Markdown formatting issues in the November issue:

- Fix "[OSPP]" prefix formatting.
- Add indented items under "GNU Toolchain for RISC-V 相关工作"
- Fix indentation for several item.