### PR TITLE
2022/2022-12-01.en.md: fix a few typos in titles

### DIFF
--- a/2022/2022-12-01.en.md
+++ b/2022/2022-12-01.en.md
@@ -208,11 +208,11 @@ Time flies and we are closing out 2022. It's a time for reflection and celebrati
 
 Review pending.
 
-## mold 相关工作
+## mold
 
 Please stay tuned.
 
-## GNU Toolchain for RISC-V 相关工作
+## GNU Toolchain for RISC-V
 
 We welcome Chen Yixuan (陈逸轩) to our team. She is currently tasked to work on low-level projects.
 


### PR DESCRIPTION
In the original translation, I have neglected to remove untranslated phrases in two section titles. This pull request addresses this oversight.