### PR TITLE
2023/2023-01-01.md: fix formatting

### DIFF
--- a/2023/2023-01-01.md
+++ b/2023/2023-01-01.md
@@ -153,7 +153,7 @@
 
   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108185#c1
   
-- Zcmt扩展的psabi修改部分在等待最终审核，感谢林思南同学的贡献：
+- Zcmt扩展的psABI修改部分在等待最终审核，感谢林思南同学的贡献：
 
   https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/349
   

--- a/2023/2023-01-01.md
+++ b/2023/2023-01-01.md
@@ -82,7 +82,8 @@
   - [Support C2 AddVB/AddVS/AddVL mask node](https://github.com/zifeihan/jdk/commit/e76367f4bde32db0f481f496b1d1cac74b95122a)
 
 ## OpenJDK8 backporting （章翔）
-1、javac 的调试工作
+
+1. javac 的调试工作
 - [Fix a typo in os_linux.cpp] https://github.com/zhangxiang-plct/jdk8u/pull/233
 - [Fix macros about RISCV] https://github.com/zhangxiang-plct/jdk8u/pull/234
 - [Fix index_check and delete condy_helper] https://github.com/zhangxiang-plct/jdk8u/pull/235
@@ -106,7 +107,7 @@
 - [Add riscv64 for unaligned in ByteArrayAccess.java]https://github.com/zhangxiang-plct/jdk8u/pull/258
 - [Add generate_dtrace_nmethod for riscv64]https://github.com/zhangxiang-plct/jdk8u/pull/259 
 
-2、C1 & C2的调试工作
+2. C1 & C2的调试工作
 - [Delete defined(RISCV64) in LIR_OpVisitState::visit] https://github.com/zhangxiang-plct/jdk8u/pull/216
 - [Fix hotspot/src/share/vm/c1/c1_LinearScan.cpp]https://github.com/zhangxiang-plct/jdk8u/pull/217
 - [Fix CounterOverflowStub::emit_code]https://github.com/zhangxiang-plct/jdk8u/pull/218


### PR DESCRIPTION
This pull request addresses two formatting issues:

- Under "OpenJDK8 backporting," fix numbered list formatting ("1、" => "1. ", etc.).
- Write `psabi` in its proper capitalised form - `psABI`.