### PR TITLE
2023-03-01.en: fix a typo in Arch Linux RISC-V

### DIFF
--- a/2023/2023-03-01.en.md
+++ b/2023/2023-03-01.en.md
@@ -175,7 +175,7 @@ See our [meeting slide deck](https://docs.google.com/presentation/d/1JjttwcSF5Mi
   - [core] 254 / 262 (96.94%)
   - [extra] 2845 / 3087 (92.16%)
   - [community] 8910 / 9949 (89.55%)
-- Git Repository for Arch Linux RISC-V package patches, [archriscv-packages](https://github.com/felixonmars/archriscv-packages). A total of [69 Pull Requests](https://github.com/felixonmars/archriscv-packages/pulls?q=is%3Apr+is%3Amerged+merged%3A2023-02-01T00%3A00%3A00%2B08%3A00..2023-02-28T23%3A59%3A59%2B08%3A00+is%3Aclosed+) 。
+- Git Repository for Arch Linux RISC-V package patches, [archriscv-packages](https://github.com/felixonmars/archriscv-packages). A total of [69 Pull Requests](https://github.com/felixonmars/archriscv-packages/pulls?q=is%3Apr+is%3Amerged+merged%3A2023-02-01T00%3A00%3A00%2B08%3A00..2023-02-28T23%3A59%3A59%2B08%3A00+is%3Aclosed+) authored this month.
   - [rust](https://github.com/felixonmars/archriscv-packages/pull/2191)
   - [glibc](https://github.com/felixonmars/archriscv-packages/pull/2188)
   - [luajit](https://github.com/felixonmars/archriscv-packages/pull/2222)


### PR DESCRIPTION
This pull request fixes a minor editorial oversight in the March report.