### PR TITLE
2023-12-01: update luajit progress

### DIFF
--- a/2023/2023-12-01.md
+++ b/2023/2023-12-01.md
@@ -56,6 +56,17 @@
 
 ## LuaJIT RV64G Porting
 
+Every known bug related to RISC-V should now be fixed, JIT is regarded as fully operational.
+We appreciate your testing and comments!
+
+- JIT
+  - [Disassembler: improve relocation resolution](https://github.com/ruyisdk/LuaJIT/commit/e1a9daac0a9fb08ed9c82fe0fa248ad36255f5d7)
+  - [Asm: fix register allocation bug in asm_hrefk](https://github.com/ruyisdk/LuaJIT/commit/c1d3628d93ecd7ba9bfcee7f7c00200c76794bc2)
+  - [Upstream: check for upvalue state transition in IR_UREFO](https://github.com/ruyisdk/LuaJIT/commit/001674e1546ced1ecaf5ced0b8139b9253c92da3)
+  - [Linux: make mremap() non-moving due to VA spaces woes](https://github.com/ruyisdk/LuaJIT/commit/8c4b59def89dcebb2cba46545e8e2aea46f7e8f4)
+  - [Asm: fix jump patcher cache flushing range](https://github.com/ruyisdk/LuaJIT/commit/d9322f3bdf0dfa29017356ea7a48a1128d808e9c)
+  - [Support: fix lj_mcode_sync, plus musl workaround](https://github.com/ruyisdk/LuaJIT/commit/3b6f3409e494efe178bd16849b5ff0df5dc885c2)
+
 ## gem5
 
 ## Spike


### PR DESCRIPTION
No more "Expect table got nil" errors. Yay!