### PR TITLE
Update OpenJDK RV64/RV32 for zifeihan in 20231201

### DIFF
--- a/2023/2023-12-01.md
+++ b/2023/2023-12-01.md
@@ -18,7 +18,23 @@
 
 ## OpenJDK Upstream
 
+7. JDK-mainline PRs:
+- https://github.com/openjdk/jdk/pull/16703 (8320280: RISC-V: Avoid passing t0 as temp register to MacroAssembler::lightweight_lock/unlock)
+
+8. JDK21U backport PRs:
+- https://github.com/openjdk/jdk21u/pull/399 (8320280: RISC-V: Avoid passing t0 as temp register to MacroAssembler::lightweight_lock/unlock)
+
+9. JDK17U backport PRs:
+- https://github.com/openjdk/jdk17u-dev/pull/1960 (8319184: RISC-V: improve MD5 intrinsic)
+- https://github.com/openjdk/jdk17u-dev/pull/1970 (8316645: RISC-V: Remove dependency on libatomic by adding cmpxchg 1b)
+
 ## OpenJDK RV32G
+- [向 OpenJDK 社区汇报 JDK11U linux/riscv32 工作进展](https://mail.openjdk.org/pipermail/riscv-port-dev/2023-November/001212.html)
+- [JDK11U RV32G C2 SPECjvm2008 测试报告](https://github.com/openjdk-riscv/jdk11u/issues/594)
+- [JDK11U RV32G C2 SPECjbb2005 测试报告](https://github.com/openjdk-riscv/jdk11u/issues/592)
+- [JDK11U RV32G C2 SPECjbb2015 测试报告](https://github.com/openjdk-riscv/jdk11u/issues/595)
+- [JDK11U RV32G C2 tier1 测试报告](https://github.com/openjdk-riscv/jdk11u/issues/596)
+- [Fix fRegD operand to add fRegD10](https://github.com/zifeihan/jdk11u/commit/cebda931e7782060eed6156650a2910b467cf37a)
 
 ## OpenJDK8 Backporting
 


### PR DESCRIPTION
Update OpenJDK RV64/RV32 for zifeihan in 20231201