### PR TITLE
Update OpenJDK RV64/RV32 for zifeihan in 20240101

### DIFF
--- a/2024/2024-01-01.md
+++ b/2024/2024-01-01.md
@@ -17,7 +17,19 @@
 
 ## OpenJDK Upstream
 
+5. JDK-mainline PRs:
+- https://github.com/openjdk/jdk/pull/17103 (8321972: test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform)
+- https://github.com/openjdk/jdk/pull/17117 (8322154: RISC-V: JDK-8315743 missed change in MacroAssembler::load_reserved)
+
+6. JDK21U backport PRs:
+- https://github.com/openjdk/jdk22/pull/19 (8322154: RISC-V: JDK-8315743 missed change in MacroAssembler::load_reserved)
+
+7. JDK17U backport PRs:
+- https://github.com/openjdk/jdk17u-dev/pull/2078 (8321972: test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform)
+
 ## OpenJDK RV32G
+- [Adding Register Groups to Long Type Registers](https://github.com/zifeihan/jdk11u/commit/cebda931e7782060eed6156650a2910b467cf37a)
+- [Align memory for gen_i2c_adapter/c2 frame structure](https://github.com/zifeihan/jdk11u/commit/6c4a4eab1785c361b772be81a2711a454e2b4609)
 
 ## OpenJDK8 Backporting
 


### PR DESCRIPTION
Update OpenJDK RV64/RV32 for zifeihan in 20240101