### PR TITLE
 Update OpenJDK RV64/RV32 for zifeihan in 20240201

### DIFF
--- a/2024/2024-02-01.md
+++ b/2024/2024-02-01.md
@@ -17,7 +17,24 @@
 
 ## OpenJDK Upstream
 
+5. JDK-mainline PRs:
+- https://github.com/openjdk/jdk/pull/17192 (8322583: RISC-V: Enable fast class initialization checks)
+- https://github.com/openjdk/jdk/pull/17436 (8323694: RISC-V: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe)
+- https://github.com/openjdk/jdk/pull/17548 (8324125: Improve class initialization barrier in TemplateTable::_new for RISC-V)
+
+6. JDK22U backport PRs:
+- https://github.com/openjdk/jdk22u/pull/34 (8324280: RISC-V: Incorrect implementation in VM_Version::parse_satp_mode)
+
+7. JDK21U backport PRs:
+- https://github.com/openjdk/jdk21u-dev/pull/132 (8322583: RISC-V: Enable fast class initialization checks)
+- https://github.com/openjdk/jdk21u-dev/pull/218 (8324280: RISC-V: Incorrect implementation in VM_Version::parse_satp_mode)
+
+8. JDK17U backport PRs:
+- https://github.com/openjdk/jdk17u-dev/pull/2110 (8322583: RISC-V: Enable fast class initialization checks)
+- https://github.com/openjdk/jdk17u-dev/pull/2178 (8324280: RISC-V: Incorrect implementation in VM_Version::parse_satp_mode)
+
 ## OpenJDK RV32G
+- https://github.com/openjdk-riscv/jdk11u/pull/597 (Add x9 to non_allocatable_reg32 group)
 
 ## OpenJDK8 Backporting
 


### PR DESCRIPTION
 Update OpenJDK RV64/RV32 for zifeihan in 20240201.