### PR TITLE
补上个月的 Aya 月报

### DIFF
--- a/2024/2024-06-01.md
+++ b/2024/2024-06-01.md
@@ -323,7 +323,40 @@ Buddy Compiler 社区 2024 OSPP 开源之夏开放项目已发布：https://summ
 
 本期没有新的进展。
 
-## Aya Theorem Prover
+## The Aya Theorem Prover
+
+[Watch Aya Prover](https://github.com/aya-prover/aya-dev)
+
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Rewrite Aya using locally nameless and HOAS+JIT compilation [PR-1042](https://github.com/aya-prover/aya-dev/pull/1042) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Make hoshino-said work [PR-1075](https://github.com/aya-prover/aya-dev/pull/1075) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Refactor of jit-compiler [PR-1074](https://github.com/aya-prover/aya-dev/pull/1074) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Increase test coverage [PR-1073](https://github.com/aya-prover/aya-dev/pull/1073) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) The `Vec` now works! Yes! [PR-1072](https://github.com/aya-prover/aya-dev/pull/1072) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Revert some code deletion, delete some unused code [PR-1071](https://github.com/aya-prover/aya-dev/pull/1071) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) data -> inductive [PR-1070](https://github.com/aya-prover/aya-dev/pull/1070) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Tycking enhancements, more testing [PR-1068](https://github.com/aya-prover/aya-dev/pull/1068) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Push telescopes [PR-1067](https://github.com/aya-prover/aya-dev/pull/1067) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Thorsten's HIIR revisited [PR-1064](https://github.com/aya-prover/aya-dev/pull/1064) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Use persistent data structure from kala [PR-1063](https://github.com/aya-prover/aya-dev/pull/1063) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Cherry pick bug fixes [PR-1062](https://github.com/aya-prover/aya-dev/pull/1062) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Random changes in library [PR-1059](https://github.com/aya-prover/aya-dev/pull/1059) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Tyck fixes [PR-1057](https://github.com/aya-prover/aya-dev/pull/1057) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.32](https://github.com/aya-prover/aya-dev/milestone/24) Normalize types [PR-1055](https://github.com/aya-prover/aya-dev/pull/1055) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Release v0.31 [PR-1054](https://github.com/aya-prover/aya-dev/pull/1054) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Trying to make library deserialization work [PR-1053](https://github.com/aya-prover/aya-dev/pull/1053) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Extract Name Serialization Methods from AbstractSerializer [PR-1052](https://github.com/aya-prover/aya-dev/pull/1052) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ More library testing [PR-1051](https://github.com/aya-prover/aya-dev/pull/1051) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Mangling & pattern tyck fix [PR-1050](https://github.com/aya-prover/aya-dev/pull/1050) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Fix lsp compile [PR-1049](https://github.com/aya-prover/aya-dev/pull/1049) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Refactor the Class Name Generator of Compiler [PR-1048](https://github.com/aya-prover/aya-dev/pull/1048) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Upgrade many things in deps and ci [PR-1047](https://github.com/aya-prover/aya-dev/pull/1047) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Document for Reducible and JitPrim should not implement Reducible [PR-1046](https://github.com/aya-prover/aya-dev/pull/1046) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Improve build, make it possible to write code with lsp [PR-1045](https://github.com/aya-prover/aya-dev/pull/1045) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.31](https://github.com/aya-prover/aya-dev/milestone/23) Implement prim serialization, do more experiments [PR-1044](https://github.com/aya-prover/aya-dev/pull/1044) opened by [ice1000](https://api.github.com/users/ice1000)
++ Post apocalypse fixes [PR-1043](https://github.com/aya-prover/aya-dev/pull/1043) opened by [ice1000](https://api.github.com/users/ice1000)
++ Do not build with graalvm [PR-1028](https://github.com/aya-prover/aya-dev/pull/1028) opened by [ice1000](https://api.github.com/users/ice1000)
++ NBE WIP [PR-318](https://github.com/aya-prover/aya-dev/pull/318) opened by [ice1000](https://api.github.com/users/ice1000)
++ Informative trace [PR-502](https://github.com/aya-prover/aya-dev/pull/502) opened by [imkiva](https://api.github.com/users/imkiva)
 
 ## eBPF
 


### PR DESCRIPTION
之前的大部分改动在另一个仓库里：https://github.com/aya-prover/locally-nameless-aya-draft

所以这个表不能代表这段时间的 Aya 全部进度，所以当时没弄进来，但我今天统计发现还是有很多东西在这里面的，所以还是补上。

今后的 PR 能更好地统计进来