### PR TITLE
Aya Prover 月报

### DIFF
--- a/2025/2025-01-01.md
+++ b/2025/2025-01-01.md
@@ -39,6 +39,83 @@
 
 ## u-boot
 
+## The Aya Theorem Prover
+
+近期更新主要亮点：
+
+- 完善表达式级别的模式匹配的支持，现在能有 Coq 那样的 `match as returns` 语法，并且实现模式匹配表达式的 JIT 编译。
+- 使用 JetBrains/markdown 代替 commonmark-java 作为文学编程模式的 markdown parser。关于这么做带来的一些语义变化，参见 [changelog](https://github.com/aya-prover/aya-dev/blob/main/note/early-changelog.md#v036)。我们随之修改了 literate Aya 的特殊语法。
+- 洞的语法 `{? M ?}` 现在支持西班牙语版本 `{¿ M ?}`，且写在里面的东西会被推导类型。之前洞里的东西是会被完全忽略的。
+- 大量关于错误信息和健壮性的改进。
+- 源码升级到 Java 22，并且使用 build-util 将字节码降级到 21（之前是降级到 17，但降级到 17 还需要做一些 API 替换。现在降级到 21 不需要做 API 替换）。
+
+[Watch Aya Prover](https://github.com/aya-prover/aya-dev)
+
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Fix a bug in literate code generation [PR-1257](https://github.com/aya-prover/aya-dev/pull/1257) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Allow injecting the literate output with datetime info [PR-1256](https://github.com/aya-prover/aya-dev/pull/1256) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Only report unimported con when the con is no-arg [PR-1253](https://github.com/aya-prover/aya-dev/pull/1253) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Patch hoshino branch as a PR [PR-1252](https://github.com/aya-prover/aya-dev/pull/1252) opened by [ice1000](https://api.github.com/users/ice1000)
++ Library additions (hoshino branch) [PR-1251](https://github.com/aya-prover/aya-dev/pull/1251) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Fix subtyping from path to pi [PR-1250](https://github.com/aya-prover/aya-dev/pull/1250) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Fix #1243 [PR-1248](https://github.com/aya-prover/aya-dev/pull/1248) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Report Error When Using Implicit Patterns with Eliminator [PR-1247](https://github.com/aya-prover/aya-dev/pull/1247) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Robustness [PR-1246](https://github.com/aya-prover/aya-dev/pull/1246) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Allow `-` and `-->` and `------------------------------------->` [PR-1244](https://github.com/aya-prover/aya-dev/pull/1244) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Improve code coverage [PR-1242](https://github.com/aya-prover/aya-dev/pull/1242) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Remove `Span` and `LineColSpan` [PR-1241](https://github.com/aya-prover/aya-dev/pull/1241) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Bug fix & slightly use more markdown doc comments [PR-1239](https://github.com/aya-prover/aya-dev/pull/1239) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Fix The Bug I Wrote [PR-1237](https://github.com/aya-prover/aya-dev/pull/1237) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Fix Wrong Implementation of `JitCon#selfTele` [PR-1235](https://github.com/aya-prover/aya-dev/pull/1235) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Release 0.36, upgrade to Java 22 [PR-1233](https://github.com/aya-prover/aya-dev/pull/1233) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Std lib updates [PR-1231](https://github.com/aya-prover/aya-dev/pull/1231) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Fix JIT of matchy calls [PR-1230](https://github.com/aya-prover/aya-dev/pull/1230) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) JIT improvements & use goal filling & report pattern errors with substed free terms [PR-1229](https://github.com/aya-prover/aya-dev/pull/1229) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Simplify concrete & improve JIT compiler [PR-1228](https://github.com/aya-prover/aya-dev/pull/1228) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Refactorings [PR-1227](https://github.com/aya-prover/aya-dev/pull/1227) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Compilation for match calls [PR-1225](https://github.com/aya-prover/aya-dev/pull/1225) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Reimplement match as a call [PR-1224](https://github.com/aya-prover/aya-dev/pull/1224) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Remove a bunch of unnecessary `Term` ops [PR-1223](https://github.com/aya-prover/aya-dev/pull/1223) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Fix another markdown generation issue [PR-1221](https://github.com/aya-prover/aya-dev/pull/1221) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) test: hopefully this fixes all the issues I've seen so far [PR-1217](https://github.com/aya-prover/aya-dev/pull/1217) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Replace commonmark with jbmd [PR-1216](https://github.com/aya-prover/aya-dev/pull/1216) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Update docs with status quo [PR-1214](https://github.com/aya-prover/aya-dev/pull/1214) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Free Java [PR-1197](https://github.com/aya-prover/aya-dev/pull/1197) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Improve the safety of `compareApprox` by slightly controlling side effects [PR-1213](https://github.com/aya-prover/aya-dev/pull/1213) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Match term `as returns` [PR-1211](https://github.com/aya-prover/aya-dev/pull/1211) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) New match term syntax concrete stuff [PR-1210](https://github.com/aya-prover/aya-dev/pull/1210) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Improve the cli output of many things [PR-1209](https://github.com/aya-prover/aya-dev/pull/1209) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) repl: only prints TopLevelDef [PR-1207](https://github.com/aya-prover/aya-dev/pull/1207) opened by [mio-19](https://api.github.com/users/mio-19)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) suppress Shadowing [PR-1206](https://github.com/aya-prover/aya-dev/pull/1206) opened by [mio-19](https://api.github.com/users/mio-19)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Introduce `aya-lexer`, slightly reorganize code [PR-1205](https://github.com/aya-prover/aya-dev/pull/1205) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Correctly report "instance not found" errors [PR-1204](https://github.com/aya-prover/aya-dev/pull/1204) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Use try-with-resource for cleanup [PR-1203](https://github.com/aya-prover/aya-dev/pull/1203) opened by [mio-19](https://api.github.com/users/mio-19)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) Unimport and correctly loading libraries in REPL [PR-1200](https://github.com/aya-prover/aya-dev/pull/1200) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.36](https://github.com/aya-prover/aya-dev/milestone/28) TRO in normalizer, report fewer unsolved meta errors [PR-1196](https://github.com/aya-prover/aya-dev/pull/1196) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Release 0.35 [PR-1192](https://github.com/aya-prover/aya-dev/pull/1192) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Pragma syntax and "suppress warnings" [PR-1191](https://github.com/aya-prover/aya-dev/pull/1191) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Introduce MathTerm [PR-1188](https://github.com/aya-prover/aya-dev/pull/1188) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Cherry pick erased patterns from match PR [PR-1190](https://github.com/aya-prover/aya-dev/pull/1190) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Cherry picks from match term [PR-1189](https://github.com/aya-prover/aya-dev/pull/1189) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) More stdlib [PR-1179](https://github.com/aya-prover/aya-dev/pull/1179) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Better code to deal with metavar refinements [PR-1186](https://github.com/aya-prover/aya-dev/pull/1186) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.10](https://github.com/aya-prover/aya-dev/milestone/1) Delay subst of Pi body [PR-93](https://github.com/aya-prover/aya-dev/pull/93) opened by [imkiva](https://api.github.com/users/imkiva)
++ [v0.16](https://github.com/aya-prover/aya-dev/milestone/7) Ensure pi body normalized [PR-350](https://github.com/aya-prover/aya-dev/pull/350) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.27](https://github.com/aya-prover/aya-dev/milestone/19) Fix sigma projection checking [PR-881](https://github.com/aya-prover/aya-dev/pull/881) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.23](https://github.com/aya-prover/aya-dev/milestone/15) Sigma transport [PR-649](https://github.com/aya-prover/aya-dev/pull/649) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.23](https://github.com/aya-prover/aya-dev/milestone/15) Computation rule of coe for binary sigma type [PR-616](https://github.com/aya-prover/aya-dev/pull/616) opened by [lunalunaa](https://api.github.com/users/lunalunaa)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Binary tuple & combine pi and sigma into depType [PR-1156](https://github.com/aya-prover/aya-dev/pull/1156) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Applying to a meta-typed term is ok, avoid reporting the same unsolved meta many times [PR-1184](https://github.com/aya-prover/aya-dev/pull/1184) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) A bunch of error report improvements [PR-1183](https://github.com/aya-prover/aya-dev/pull/1183) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix #1178 [PR-1182](https://github.com/aya-prover/aya-dev/pull/1182) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Add `connect`, `disconnect` APIs, change related functions to perform necessary cleanups [PR-1176](https://github.com/aya-prover/aya-dev/pull/1176) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) doc: fix imkiva blog link in readme [PR-1180](https://github.com/aya-prover/aya-dev/pull/1180) opened by [mio-19](https://api.github.com/users/mio-19)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix head normalization [PR-1175](https://github.com/aya-prover/aya-dev/pull/1175) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix #1037 and check my cubical knowledge [PR-1170](https://github.com/aya-prover/aya-dev/pull/1170) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Projection Typecheck [PR-1171](https://github.com/aya-prover/aya-dev/pull/1171) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix #1151 [PR-1168](https://github.com/aya-prover/aya-dev/pull/1168) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix 1135 [PR-1167](https://github.com/aya-prover/aya-dev/pull/1167) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.35](https://github.com/aya-prover/aya-dev/milestone/27) Fix #1155 [PR-1166](https://github.com/aya-prover/aya-dev/pull/1166) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
+
 ## Arch Linux
 
 ## RevyOS (Debian for Xuantie)


### PR DESCRIPTION
近期更新主要亮点：

- 完善表达式级别的模式匹配的支持，现在能有 Coq 那样的 `match as returns` 语法，并且实现模式匹配表达式的 JIT 编译。
- 使用 JetBrains/markdown 代替 commonmark-java 作为文学编程模式的 markdown parser。关于这么做带来的一些语义变化，参见 [changelog](https://github.com/aya-prover/aya-dev/blob/main/note/early-changelog.md#v036)。我们随之修改了 literate Aya 的特殊语法。
- 洞的语法 `{? M ?}` 现在支持西班牙语版本 `{¿ M ?}`，且写在里面的东西会被推导类型。之前洞里的东西是会被完全忽略的。
- 大量关于错误信息和健壮性的改进。
- 源码升级到 Java 22，并且使用 build-util 将字节码降级到 21（之前是降级到 17，但降级到 17 还需要做一些 API 替换。现在降级到 21 不需要做 API 替换）。