### PR TITLE
Add Aya progress

### DIFF
--- a/2025/2025-02-01.md
+++ b/2025/2025-02-01.md
@@ -159,6 +159,39 @@ RuyiSDK 软件的打包与分发工作：目前您可以直接在 GitHub 上查�
 
 本期没有新的进展。
 
+## The Aya Theorem Prover
+
+[Watch Aya Prover](https://github.com/aya-prover/aya-dev)
+
+本月主要亮点：
+
+* 字节码生成实现了优化器。事实证明 switch 两个分支（其中一个是 default）比 if else 的字节码体积要更大。这一知识在 StackOverflow 上无法获取，因为不论你怎么提问，都会有人告诉你这是过早优化，是万恶之源。但我 codegen 里面会生成无数的这样的代码，那么生成更短的代码在执行性能完全等价的情况下会很有优势。
+* 在 REPL 里面可以看 case tree 了，用 `:case-tree` 命令后面跟函数名。
+* 细化 pattern 功能终于实现了。现在 Aya 会对某些模式匹配进行修改使得可以推进更多的类型计算。这一功能被称为「愿原力与你同在」，因为原力的英语 force 和模式匹配中对推导生成的模式 forced pattern 同名。
+* Lambda 表达式可以模式匹配了，会解糖成 lambda 后面跟着模式匹配表达式。语法是 `\ { zero, suc n => ... }`，同时也支持 `\ ()` 这个语法。
+* 优化核心语法树上部分操作。
+
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Turn some classes into records [PR-1292](https://github.com/aya-prover/aya-dev/pull/1292) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Remove unused gradle task `:githubActions` [PR-1291](https://github.com/aya-prover/aya-dev/pull/1291) opened by [mio-19](https://api.github.com/users/mio-19)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) More docs & comments about the codebase [PR-1290](https://github.com/aya-prover/aya-dev/pull/1290) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) MAY THE FORCE BE WITH YOU [PR-1289](https://github.com/aya-prover/aya-dev/pull/1289) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Try to make the force be with you [PR-1288](https://github.com/aya-prover/aya-dev/pull/1288) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Implement `:case-tree` in repl [PR-1287](https://github.com/aya-prover/aya-dev/pull/1287) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Pretty print JIT-compiled telescope [PR-1286](https://github.com/aya-prover/aya-dev/pull/1286) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Simplify confluence check [PR-1285](https://github.com/aya-prover/aya-dev/pull/1285) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Irrefutable Lambda [PR-1283](https://github.com/aya-prover/aya-dev/pull/1283) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Use `bindAllFrom` primitively [PR-1282](https://github.com/aya-prover/aya-dev/pull/1282) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Pretty Print and Highlight for Pragma [PR-1281](https://github.com/aya-prover/aya-dev/pull/1281) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.38](https://github.com/aya-prover/aya-dev/milestone/30) Fix #1274 [PR-1280](https://github.com/aya-prover/aya-dev/pull/1280) opened by [HoshinoTented](https://api.github.com/users/HoshinoTented)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Release v0.37 [PR-1279](https://github.com/aya-prover/aya-dev/pull/1279) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.34](https://github.com/aya-prover/aya-dev/milestone/26) Error handling, handle `RuleReducer.Con` in `visibleArgs` in `CorePrettier` [PR-1148](https://github.com/aya-prover/aya-dev/pull/1148) opened by [ice1000](https://api.github.com/users/ice1000)
++ version: release 0.30 [PR-1025](https://github.com/aya-prover/aya-dev/pull/1025) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) JIT compiler should generate fewer things [PR-1278](https://github.com/aya-prover/aya-dev/pull/1278) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Initial optimizer [PR-1272](https://github.com/aya-prover/aya-dev/pull/1272) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Free java [PR-1271](https://github.com/aya-prover/aya-dev/pull/1271) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Highlight import as two segments: the prefix and the last … [PR-1270](https://github.com/aya-prover/aya-dev/pull/1270) opened by [ice1000](https://api.github.com/users/ice1000)
++ [v0.37](https://github.com/aya-prover/aya-dev/milestone/29) Better pat tyck [PR-1268](https://github.com/aya-prover/aya-dev/pull/1268) opened by [ice1000](https://api.github.com/users/ice1000)
+
 ## Arch Linux
 
 ## RevyOS (Debian for Xuantie)


### PR DESCRIPTION
* 字节码生成实现了优化器。事实证明 switch 两个分支（其中一个是 default）比 if else 的字节码体积要更大。这一知识在 StackOverflow 上无法获取，因为不论你怎么提问，都会有人告诉你这是过早优化，是万恶之源。但我 codegen 里面会生成无数的这样的代码，那么生成更短的代码在执行性能完全等价的情况下会很有优势。
* 在 REPL 里面可以看 case tree 了，用 `:case-tree` 命令后面跟函数名。
* 细化 pattern 功能终于实现了。现在 Aya 会对某些模式匹配进行修改使得可以推进更多的类型计算。这一功能被称为「愿原力与你同在」，因为原力的英语 force 和模式匹配中对推导生成的模式 forced pattern 同名。
* Lambda 表达式可以模式匹配了，会解糖成 lambda 后面跟着模式匹配表达式。语法是 `\ { zero, suc n => ... }`，同时也支持 `\ ()` 这个语法。
* 优化核心语法树上部分操作。